### PR TITLE
uses text template for email text message

### DIFF
--- a/dispatch.go
+++ b/dispatch.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"html/template"
 	"io/ioutil"
 	"path"
 	"path/filepath"
 	"reflect"
+	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
 	log "github.com/sirupsen/logrus"
@@ -46,7 +46,7 @@ func NewDispatch(targetDir string, smtpSettings SMTPSettings) *Dispatch {
 {{ index . "message"}}
 `
 
-	d.messageTemplate = template.Must(template.New("request").Funcs(sprig.FuncMap()).Parse(msg))
+	d.messageTemplate = template.Must(template.New("request").Funcs(sprig.TxtFuncMap()).Parse(msg))
 	d.LoadTargets(targetDir)
 	return d
 }


### PR DESCRIPTION
This fixes message transcoding of unicode characters to html entities.
E.g. ``+`` shown as ``&#43;``   

Because currently only text mails are sent this behavior seems more correct.  
If ``Message.HTMLMessage`` is set somewhere in the future then ``html/template`` can be used again.
